### PR TITLE
fix: manually handle redirects for the web scraper and deprecate the

### DIFF
--- a/packages/docbox-web-scraper/src/document.rs
+++ b/packages/docbox-web-scraper/src/document.rs
@@ -9,6 +9,11 @@ use thiserror::Error;
 use tl::{HTMLTag, Parser};
 use url::Url;
 
+use crate::{
+    request::{RequestError, get_request},
+    url_validation::UrlValidation,
+};
+
 /// Metadata extracted from a website
 #[derive(Debug)]
 pub struct WebsiteMetadata {
@@ -44,11 +49,8 @@ struct WebsiteDocumentState {
 /// Errors that could occur when website metadata is loaded
 #[derive(Debug, Error)]
 pub enum WebsiteMetadataError {
-    #[error("failed to request resource")]
-    FailedRequest(reqwest::Error),
-
-    #[error("error response from server")]
-    ErrorResponse(reqwest::Error),
+    #[error(transparent)]
+    Request(#[from] RequestError),
 
     #[error("failed to read response")]
     ReadResponse(reqwest::Error),
@@ -74,7 +76,7 @@ pub enum WebsiteMetadataParseError {
 
 /// Connects to a website reading the HTML contents, extracts the metadata
 /// required from the <head/> element
-pub async fn get_website_metadata(
+pub async fn get_website_metadata<D: UrlValidation>(
     client: &reqwest::Client,
     url: &Url,
 ) -> Result<WebsiteMetadata, WebsiteMetadataError> {
@@ -90,13 +92,7 @@ pub async fn get_website_metadata(
     }
 
     // Request page at URL
-    let response = client
-        .get(url)
-        .send()
-        .await
-        .map_err(WebsiteMetadataError::FailedRequest)?
-        .error_for_status()
-        .map_err(WebsiteMetadataError::ErrorResponse)?;
+    let (response, _redirects) = get_request::<D>(client, url).await?;
 
     // Read response text
     let text = response
@@ -110,11 +106,8 @@ pub async fn get_website_metadata(
 /// Error's that can occur when attempting to load robots.txt
 #[derive(Debug, Error)]
 pub enum RobotsTxtError {
-    #[error("failed to request resource")]
-    FailedRequest(reqwest::Error),
-
-    #[error("error response from server")]
-    ErrorResponse(reqwest::Error),
+    #[error(transparent)]
+    Request(#[from] RequestError),
 
     #[error("failed to read response")]
     ReadResponse(reqwest::Error),
@@ -122,7 +115,7 @@ pub enum RobotsTxtError {
 
 /// Attempts to read the robots.txt file for the website to determine if
 /// scraping is allowed
-pub async fn is_allowed_robots_txt(
+pub async fn is_allowed_robots_txt<D: UrlValidation>(
     client: &reqwest::Client,
     url: &Url,
 ) -> Result<bool, RobotsTxtError> {
@@ -134,13 +127,7 @@ pub async fn is_allowed_robots_txt(
     url.set_path("/robots.txt");
 
     // Request page at URL
-    let response = client
-        .get(url)
-        .send()
-        .await
-        .map_err(RobotsTxtError::FailedRequest)?
-        .error_for_status()
-        .map_err(RobotsTxtError::ErrorResponse)?;
+    let (response, _redirects) = get_request::<D>(client, url).await?;
 
     // Read response text
     let robots_txt = response

--- a/packages/docbox-web-scraper/src/download_image.rs
+++ b/packages/docbox-web-scraper/src/download_image.rs
@@ -4,7 +4,11 @@
 
 use std::{fmt::Debug, pin::Pin, task::Poll};
 
-use crate::data_uri::{DataUriError, parse_data_uri};
+use crate::{
+    data_uri::{DataUriError, parse_data_uri},
+    request::{RequestError, get_request},
+    url_validation::UrlValidation,
+};
 use bytes::Bytes;
 use futures::{Stream, TryStreamExt};
 use mime::Mime;
@@ -15,13 +19,9 @@ use tracing::debug;
 /// Error's that can occur when downloading an image
 #[derive(Debug, Error)]
 pub enum DownloadImageError {
-    /// Error making the request
+    /// Error performing the request
     #[error(transparent)]
-    Request(reqwest::Error),
-
-    /// Error as the response status
-    #[error(transparent)]
-    Response(reqwest::Error),
+    Request(#[from] RequestError),
 
     /// Error when downloading the response
     #[error(transparent)]
@@ -102,7 +102,7 @@ impl Stream for ImageStream {
 }
 
 /// Downloads an image file from a href relative to the `base_url`
-pub async fn download_image_href(
+pub async fn download_image_href<D: UrlValidation>(
     client: &reqwest::Client,
     url: ResolvedUri<'_>,
 ) -> Result<(ImageStream, Mime), DownloadImageError> {
@@ -121,7 +121,7 @@ pub async fn download_image_href(
 
         ResolvedUri::Absolute(url) => {
             debug!(%url, "requesting remote image");
-            download_image(client, url).await
+            download_image::<D>(client, url).await
         }
     }
 }
@@ -129,18 +129,12 @@ pub async fn download_image_href(
 /// Downloads an image from a `url` ensures the returned content-type
 /// is an image before attempting to stream the download bytes. Will
 /// error if the content-type is missing or not an image/* type
-async fn download_image(
+async fn download_image<D: UrlValidation>(
     client: &reqwest::Client,
     url: Url,
 ) -> Result<(ImageStream, Mime), DownloadImageError> {
     // Request page at URL
-    let response = client
-        .get(url)
-        .send()
-        .await
-        .map_err(DownloadImageError::Request)?
-        .error_for_status()
-        .map_err(DownloadImageError::Response)?;
+    let (response, _redirects) = get_request::<D>(client, url).await?;
 
     let headers = response.headers();
     let content_type = headers

--- a/packages/docbox-web-scraper/src/lib.rs
+++ b/packages/docbox-web-scraper/src/lib.rs
@@ -16,17 +16,18 @@
 //! * `DOCBOX_WEB_SCRAPE_METADATA_READ_TIMEOUT` - Timeout when reading responses from scraping
 
 use document::{determine_best_favicon, get_website_metadata};
-use download_image::{ResolvedUri, download_image_href, resolve_full_url};
+use download_image::{download_image_href, resolve_full_url};
 use mime::Mime;
-use reqwest::Proxy;
+use reqwest::{Proxy, redirect::Policy};
 use serde::{Deserialize, Serialize};
 use std::{str::FromStr, time::Duration};
 use thiserror::Error;
-use url_validation::{TokioDomainResolver, is_allowed_url};
+use url_validation::TokioDomainResolver;
 
 mod data_uri;
 mod document;
 mod download_image;
+mod request;
 mod url_validation;
 
 pub use document::Favicon;
@@ -154,6 +155,12 @@ impl WebsiteMetaService {
     }
 
     /// Create a web scraper from the provided client
+    ///
+    /// Using a custom client can cause security measures to not
+    /// be fully applied leading to gaps in security its recommended
+    /// you use [WebsiteMetaService::from_config] unless you have a
+    /// specific use case which is prevented by it
+    #[deprecated]
     pub fn from_client(client: reqwest::Client) -> Self {
         Self { client }
     }
@@ -174,6 +181,11 @@ impl WebsiteMetaService {
             .user_agent("DocboxLinkBot")
             .connect_timeout(config.metadata_connect_timeout)
             .read_timeout(config.metadata_read_timeout)
+            // Redirect logic is handled internally by the scraper for security
+            .redirect(Policy::none())
+            // Enforce our custom tokio lookup_host based resolver to ensure
+            // consistency when blocking requests
+            .dns_resolver(TokioDomainResolver)
             .build()?;
 
         Ok(Self { client })
@@ -181,14 +193,8 @@ impl WebsiteMetaService {
 
     /// Resolves the metadata for the website at the provided URL
     pub async fn resolve_website(&self, url: &Url) -> Option<ResolvedWebsiteMetadata> {
-        // Check if we are allowed to access the URL
-        if !is_allowed_url::<TokioDomainResolver>(url).await {
-            tracing::warn!("skipping resolve website metadata for disallowed url");
-            return None;
-        }
-
         // Check that the site allows scraping based on its robots.txt
-        let is_allowed_scraping = is_allowed_robots_txt(&self.client, url)
+        let is_allowed_scraping = is_allowed_robots_txt::<TokioDomainResolver>(&self.client, url)
             .await
             .unwrap_or(false);
 
@@ -197,7 +203,7 @@ impl WebsiteMetaService {
         }
 
         // Get the website metadata
-        let res = match get_website_metadata(&self.client, url).await {
+        let res = match get_website_metadata::<TokioDomainResolver>(&self.client, url).await {
             Ok(value) => value,
             Err(error) => {
                 tracing::error!(?error, "failed to get website metadata");
@@ -257,15 +263,10 @@ impl WebsiteMetaService {
     pub async fn resolve_image(&self, url: &Url, image: &str) -> Option<ResolvedImage> {
         let image_url = resolve_full_url(url, image).ok()?;
 
-        // Check we are allowed to access the URL if its absolute
-        if let ResolvedUri::Absolute(image_url) = &image_url
-            && !is_allowed_url::<TokioDomainResolver>(image_url).await
-        {
-            tracing::warn!("skipping resolve image for disallowed url");
-            return None;
-        }
-
-        let (stream, content_type) = download_image_href(&self.client, image_url).await.ok()?;
+        let (stream, content_type) =
+            download_image_href::<TokioDomainResolver>(&self.client, image_url)
+                .await
+                .ok()?;
 
         Some(ResolvedImage {
             content_type,

--- a/packages/docbox-web-scraper/src/request.rs
+++ b/packages/docbox-web-scraper/src/request.rs
@@ -1,0 +1,214 @@
+use crate::url_validation::UrlValidation;
+use reqwest::{Response, StatusCode, header};
+use thiserror::Error;
+use url::Url;
+
+const MAX_REDIRECT_ATTEMPTS: usize = 5;
+
+#[derive(Debug, Error)]
+pub enum RequestError {
+    #[error("failed to request resource")]
+    FailedRequest(reqwest::Error),
+
+    #[error("error response from server")]
+    ErrorResponse(reqwest::Error),
+
+    #[error("disallowed target url")]
+    DisallowedUrl,
+
+    #[error("broken redirect")]
+    BrokenRedirect,
+
+    #[error("too many redirects")]
+    TooManyRedirects,
+}
+
+pub async fn get_request<D: UrlValidation>(
+    client: &reqwest::Client,
+    url: Url,
+) -> Result<(Response, usize), RequestError> {
+    let mut redirect_attempts = MAX_REDIRECT_ATTEMPTS;
+    let mut current_url = url;
+
+    while redirect_attempts > 0 {
+        let is_allowed = D::is_allowed_url(&current_url).await;
+        if !is_allowed {
+            tracing::warn!("skipping request for disallowed url: {current_url}");
+            return Err(RequestError::DisallowedUrl);
+        }
+
+        let response = client
+            .get(current_url.clone())
+            .send()
+            .await
+            .map_err(RequestError::FailedRequest)?
+            .error_for_status()
+            .map_err(RequestError::ErrorResponse)?;
+
+        if !matches!(
+            response.status(),
+            StatusCode::MOVED_PERMANENTLY
+                | StatusCode::FOUND
+                | StatusCode::SEE_OTHER
+                | StatusCode::TEMPORARY_REDIRECT
+                | StatusCode::PERMANENT_REDIRECT
+        ) {
+            return Ok((response, MAX_REDIRECT_ATTEMPTS - redirect_attempts));
+        }
+
+        let headers = response.headers();
+        let location = headers
+            .get(header::LOCATION)
+            .ok_or_else(|| RequestError::BrokenRedirect)?;
+
+        let location = location
+            .to_str()
+            .map_err(|_| RequestError::BrokenRedirect)?;
+
+        // .join handles ./, ../, /, and event new URLs so all Location: cases are handled
+        let next_url = current_url
+            .join(location)
+            .map_err(|_| RequestError::BrokenRedirect)?;
+
+        current_url = next_url;
+        redirect_attempts -= 1;
+    }
+
+    Err(RequestError::TooManyRedirects)
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::{Client, redirect::Policy};
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+        task::AbortHandle,
+    };
+
+    use crate::url_validation::TokioDomainResolver;
+
+    use super::*;
+
+    struct AbortOnDrop(AbortHandle);
+
+    impl Drop for AbortOnDrop {
+        fn drop(&mut self) {
+            self.0.abort();
+        }
+    }
+
+    async fn mock_http_server(response: String) -> (Url, AbortOnDrop) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("Failed to bind local server");
+        let local_addr = listener.local_addr().expect("Failed to get local address");
+
+        let handle = tokio::spawn(async move {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                let mut buf = [0; 1024];
+                // Read incoming headers (we can ignore the contents for this test)
+                let _ = socket.read(&mut buf).await;
+
+                let _ = socket.write_all(response.as_bytes()).await;
+                let _ = socket.flush().await;
+            }
+        })
+        .abort_handle();
+
+        (
+            Url::parse(&format!("http://{}", local_addr)).unwrap(),
+            AbortOnDrop(handle),
+        )
+    }
+
+    async fn spawn_redirect_server(next_url: String) -> (Url, AbortOnDrop) {
+        let response = format!(
+            "HTTP/1.1 307 Temporary Redirect\r\n\
+                    Location: {next_url}\r\n\
+                    Content-Length: 0\r\n\
+                    Connection: close\r\n\
+                    \r\n"
+        );
+
+        mock_http_server(response).await
+    }
+
+    struct MockUrlValidation;
+
+    impl UrlValidation for MockUrlValidation {
+        async fn is_allowed_url(url: &Url) -> bool {
+            // We need at least one address locally that we can visit
+            // in order to run the mock server
+            if url.host_str().unwrap() == "127.0.0.1" {
+                return true;
+            }
+
+            TokioDomainResolver::is_allowed_url(url).await
+        }
+    }
+
+    /// Tests encountering redirects that reaches an allowed server
+    #[tokio::test]
+    async fn test_redirect_real() {
+        let response = "HTTP/1.1 204 No Content\r\n\
+                    Content-Length: 0\r\n\
+                    Connection: close\r\n\
+                    \r\n"
+            .to_string();
+
+        let (url_4, _handle) = mock_http_server(response).await;
+        let (url_3, _handle) = spawn_redirect_server(url_4.to_string()).await;
+        let (url_2, _handle) = spawn_redirect_server(url_3.to_string()).await;
+        let (url_1, _handle) = spawn_redirect_server(url_2.to_string()).await;
+        let client = Client::builder()
+            .user_agent("DocboxLinkBot")
+            .redirect(Policy::none())
+            .build()
+            .unwrap();
+
+        let (_response, redirects) = get_request::<MockUrlValidation>(&client, url_1)
+            .await
+            .unwrap();
+
+        assert_eq!(redirects, 3);
+    }
+
+    /// Tests encountering a bad redirect
+    #[tokio::test]
+    async fn test_redirect_real_disallowed_url() {
+        let (url, _handle) = spawn_redirect_server("http://127.0.0.2".to_string()).await;
+        let client = Client::builder()
+            .user_agent("DocboxLinkBot")
+            .redirect(Policy::none())
+            .build()
+            .unwrap();
+
+        let error = get_request::<MockUrlValidation>(&client, url)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, RequestError::DisallowedUrl));
+    }
+
+    /// Tests following a chain of two good redirects leading to a third bad redirect
+    /// which should be blocked
+    #[tokio::test]
+    async fn test_redirect_real_disallowed_url_chain() {
+        let (url_3, _handle) = spawn_redirect_server("http://127.0.0.2".to_string()).await;
+        let (url_2, _handle) = spawn_redirect_server(url_3.to_string()).await;
+        let (url_1, _handle) = spawn_redirect_server(url_2.to_string()).await;
+
+        let client = Client::builder()
+            .user_agent("DocboxLinkBot")
+            .redirect(Policy::none())
+            .build()
+            .unwrap();
+
+        let error = get_request::<MockUrlValidation>(&client, url_1)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, RequestError::DisallowedUrl));
+    }
+}

--- a/packages/docbox-web-scraper/src/url_validation.rs
+++ b/packages/docbox-web-scraper/src/url_validation.rs
@@ -18,6 +18,20 @@ pub(crate) trait DomainResolver {
 /// Domain resolver backed by tokio's resolution
 pub struct TokioDomainResolver;
 
+impl reqwest::dns::Resolve for TokioDomainResolver {
+    fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
+        let name_str = name.as_str();
+        let host_with_port = format!("{}:0", name_str);
+
+        Box::pin(async move {
+            let resolved = tokio::net::lookup_host(host_with_port).await?;
+            let resolved: Vec<SocketAddr> = resolved.collect();
+
+            Ok(Box::new(resolved.into_iter()) as reqwest::dns::Addrs)
+        })
+    }
+}
+
 impl DomainResolver for TokioDomainResolver {
     async fn resolve_domain(
         host: &str,
@@ -28,6 +42,17 @@ impl DomainResolver for TokioDomainResolver {
 }
 
 const ALLOWED_SCHEMES: &[&str] = &["http", "https"];
+
+/// Validator ensuring the URL is an allowed url for fetching
+pub(crate) trait UrlValidation {
+    async fn is_allowed_url(url: &Url) -> bool;
+}
+
+impl UrlValidation for TokioDomainResolver {
+    async fn is_allowed_url(url: &Url) -> bool {
+        is_allowed_url::<TokioDomainResolver>(url).await
+    }
+}
 
 /// Validates that the provided `url` is valid for the web-scraper
 /// to visit.


### PR DESCRIPTION
from_client functionality